### PR TITLE
Changed `wurzel` to lower-case

### DIFF
--- a/Schlange.py
+++ b/Schlange.py
@@ -41,7 +41,7 @@ class KeywordTranslator:
         "selbst" : "self",
         "drucke" : "print",
         "mathe" : "math",
-        "Wurzel" : "sqrt"
+        "wurzel" : "sqrt"
     }
     #dictionary to interpret the exceptions
     translation_exceptions = {


### PR DESCRIPTION
Changed `wurzel` to lower-case according to Python's naming convention.

As mentioned in @AntonPieper's [comment](https://github.com/actopozipc/German-Python-Interpreter/pull/4#issuecomment-1586303657) in #4 