### PR TITLE
add "next" keyword, better "yield" translation and generator example

### DIFF
--- a/Examples/prim_generator.sch
+++ b/Examples/prim_generator.sch
@@ -1,0 +1,17 @@
+def prim_generator():
+    zahl = 2
+    solange Wahr:
+        ist_prim = Wahr
+        für teiler in reichweite(2, int(zahl ** 0.5) + 1):
+            wenn zahl % teiler == 0:
+                breche
+        sonst:
+            ergebe zahl
+        zahl += 1
+
+gen = prim_generator()
+
+anzahl_primzahlen = 100
+
+für x in reichweite(1, anzahl_primzahlen + 1):
+    drucke(nächstes(gen))

--- a/Schlange.py
+++ b/Schlange.py
@@ -36,12 +36,13 @@ class KeywordTranslator:
         'versuche': 'try',
         'solange': 'while',
         'mit': 'with',
-        'erzeuge': 'yield',
+        'ergebe': 'yield',
         "reichweite" : "range",
         "selbst" : "self",
         "drucke" : "print",
         "mathe" : "math",
-        "wurzel" : "sqrt"
+        "wurzel" : "sqrt",
+        "nächstes" : "next"
     }
     #dictionary to interpret the exceptions
     translation_exceptions = {


### PR DESCRIPTION
I find the word "ergebe" a lot more accurate than "erzeuge", as "erzeuge" is a lot closer to something like "create". "Ergebe" fits a lot better with what a generator actually is in my opinion.

Also, i added "nächstes" as a translation for "next" so you can actually use generators :).

The `prim_generator.sch` is just an example of a generator that uses the new keywords.